### PR TITLE
Rust - 2019 - Day one - even more fuel

### DIFF
--- a/rust/2019/day1/instructions.txt
+++ b/rust/2019/day1/instructions.txt
@@ -19,3 +19,16 @@ For a mass of 100756, the fuel required is 33583.
 The Fuel Counter-Upper needs to know the total fuel requirement. To find it, individually calculate the fuel needed for the mass of each module (your puzzle input), then add together all the fuel values.
 
 What is the sum of the fuel requirements for all of the modules on your spacecraft?
+
+--- Part Two ---
+
+During the second Go / No Go poll, the Elf in charge of the Rocket Equation Double-Checker stops the launch sequence. Apparently, you forgot to include additional fuel for the fuel you just added.
+
+Fuel itself requires fuel just like a module - take its mass, divide by three, round down, and subtract 2. However, that fuel also requires fuel, and that fuel requires fuel, and so on. Any mass that would require negative fuel should instead be treated as if it requires zero fuel; the remaining mass, if any, is instead handled by wishing really hard, which has no mass and is outside the scope of this calculation.
+
+So, for each module mass, calculate its fuel and add it to the total. Then, treat the fuel amount you just calculated as the input mass and repeat the process, continuing until a fuel requirement is zero or negative. For example:
+
+A module of mass 14 requires 2 fuel. This fuel requires no further fuel (2 divided by 3 and rounded down is 0, which would call for a negative fuel), so the total fuel required is still just 2.
+At first, a module of mass 1969 requires 654 fuel. Then, this fuel requires 216 more fuel (654 / 3 - 2). 216 then requires 70 more fuel, which requires 21 fuel, which requires 5 fuel, which requires no further fuel. So, the total fuel required for a module of mass 1969 is 654 + 216 + 70 + 21 + 5 = 966.
+The fuel required by a module of mass 100756 and its fuel is: 33583 + 11192 + 3728 + 1240 + 411 + 135 + 43 + 12 + 2 = 50346.
+What is the sum of the fuel requirements for all of the modules on your spacecraft when also taking into account the mass of the added fuel? (Calculate the fuel requirements for each module separately, then add them all up at the end.)

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -4,7 +4,12 @@ use std::fs;
 struct Module { mass: u64 }
 
 impl Module {
-    fn calculate_fuel(&self) -> u64 {
+    fn calculate_fuel_part1(&self) -> u64 {
+        let x: f64 = self.mass as f64 / 3.0;
+        x.floor() as u64 - 2
+    }
+
+    fn calculate_fuel_part2(&self) -> u64 {
         let x: f64 = self.mass as f64 / 3.0;
         x.floor() as u64 - 2
     }
@@ -33,7 +38,7 @@ fn part1(file_path: &str) -> u64 {
     let input_masses = read_input(file_path);
     let modules = collect_modules(input_masses);
 
-    modules.iter().map(|module| module.calculate_fuel()).sum()
+    modules.iter().map(|module| module.calculate_fuel_part1()).sum()
 }
 
 fn main() {
@@ -48,11 +53,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_calculate_fuel() {
-        assert_eq!(Module { mass: 12 }.calculate_fuel(), 2);
-        assert_eq!(Module { mass: 14 }.calculate_fuel(), 2);
-        assert_eq!(Module { mass: 1969 }.calculate_fuel(), 654);
-        assert_eq!(Module { mass: 100756 }.calculate_fuel(), 33583);
+    fn test_calculate_fuel_part1() {
+        assert_eq!(Module { mass: 12 }.calculate_fuel_part1(), 2);
+        assert_eq!(Module { mass: 14 }.calculate_fuel_part1(), 2);
+        assert_eq!(Module { mass: 1969 }.calculate_fuel_part1(), 654);
+        assert_eq!(Module { mass: 100756 }.calculate_fuel_part1(), 33583);
+    }
+
+    #[test]
+    fn test_calculate_fuel_part2() {
+        assert_eq!(Module { mass: 12 }.calculate_fuel_part2(), 2);
+        assert_eq!(Module { mass: 14 }.calculate_fuel_part2(), 2);
+        assert_eq!(Module { mass: 1969 }.calculate_fuel_part2(), 966);
+        // assert_eq!(Module { mass: 100756 }.calculate_fuel_part2(), 50346);
     }
 
     #[test]

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 struct Module {
     mass: u64,
 }
@@ -9,14 +11,54 @@ impl Module {
     }
 }
 
+// fn read_input(file_path: &str) -> Vec<String> {
+fn read_input(file_path: &str) -> Vec<u64> {
+    let mut new_vec = vec![];
+    // let mut new_vec: Vec<String> = Vec::new();
+    // let contents = fs::read_to_string(file_path).expect("Unable to read file").split("\n").collect();
+
+    // TODO: figure out why try the next three lines on one results in error E0716:
+    // creates a temporary which is freed while still in use
+    // let contents: Vec<&str> = fs::read_to_string(file_path).expect("Unable to read file").split("\n").collect();
+    // println!("Got contents: {:?}", raw_contents);
+
+    // Instead have to get the raw contents and then collect them :shrug:
+    let raw_contents = fs::read_to_string(file_path).expect("Unable to read file");
+    println!("Got raw_contents: {:?}", raw_contents);
+    let contents: Vec<&str> = raw_contents.split("\n").collect();
+
+    for line in contents {
+        println!("Processing line: {}", line);
+        // TODO: there must be a way to chomp final new line - just couldn't find it right away
+        if line != "" {
+            new_vec.push(
+                line.to_string()
+                .parse::<u64>()
+                .expect("Unable to parse string to integer")
+            );
+        }
+    }
+    new_vec
+}
+
 fn main() {
     println!("Hello, world!");
 }
 
-#[test]
-fn test_calculate_fuel() {
-    assert_eq!(Module { mass: 12 }.calculate_fuel(), 2);
-    assert_eq!(Module { mass: 14 }.calculate_fuel(), 2);
-    assert_eq!(Module { mass: 1969 }.calculate_fuel(), 654);
-    assert_eq!(Module { mass: 100756 }.calculate_fuel(), 33583);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_fuel() {
+        assert_eq!(Module { mass: 12 }.calculate_fuel(), 2);
+        assert_eq!(Module { mass: 14 }.calculate_fuel(), 2);
+        assert_eq!(Module { mass: 1969 }.calculate_fuel(), 654);
+        assert_eq!(Module { mass: 100756 }.calculate_fuel(), 33583);
+    }
+
+    #[test]
+    fn test_read_input() {
+        assert_eq!(read_input("test_input.txt"), vec![12, 14, 1969, 100756])
+    }
 }

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -1,5 +1,6 @@
 use std::fs;
 
+#[derive(Debug, PartialEq)]
 struct Module {
     mass: u64,
 }
@@ -41,6 +42,30 @@ fn read_input(file_path: &str) -> Vec<u64> {
     new_vec
 }
 
+// TODO: ditch these function once all is working as desired
+fn sum_input(file_path: &str) -> u64 {
+    read_input(file_path).iter().sum()
+}
+
+fn collect_modules(input_masses: Vec<u64>) -> Vec<Module> {
+    let mut modules = vec![];
+    for mass in input_masses.iter() {
+        modules.push(Module { mass: *mass })
+    }
+    modules
+}
+
+fn part1(file_path: &str) -> u64 {
+    let input_masses = read_input(file_path);
+    let modules = collect_modules(input_masses);
+
+    let mut fuel_calculations = vec![];
+    for module in modules {
+        fuel_calculations.push(module.calculate_fuel());
+    }
+    fuel_calculations.iter().sum()
+}
+
 fn main() {
     println!("Hello, world!");
 }
@@ -60,5 +85,28 @@ mod tests {
     #[test]
     fn test_read_input() {
         assert_eq!(read_input("test_input.txt"), vec![12, 14, 1969, 100756])
+    }
+
+    #[test]
+    fn test_collect_modules() {
+        let input_masses = read_input("test_input.txt");
+        assert_eq!(collect_modules(input_masses), vec![
+            Module { mass: 12 },
+            Module { mass: 14 },
+            Module { mass: 1969 },
+            Module { mass: 100756 },
+        ])
+    }
+
+    #[test]
+    fn test_part1() {
+        let input_file = "test_input.txt";
+        assert_eq!(part1(input_file), 34241);
+    }
+
+    #[test]
+    // TODO: delete this test once it is all working =)
+    fn test_sum_input() {
+        assert_eq!(sum_input("test_input.txt"), 102751)
     }
 }

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -5,14 +5,40 @@ struct Module { mass: u64 }
 
 impl Module {
     fn calculate_fuel_part1(&self) -> u64 {
-        let x: f64 = self.mass as f64 / 3.0;
-        x.floor() as u64 - 2
+        calculate_fuel(self.mass)
     }
 
     fn calculate_fuel_part2(&self) -> u64 {
-        let x: f64 = self.mass as f64 / 3.0;
-        x.floor() as u64 - 2
+        let mut total_fuel: u64 = 0;
+        let mut mass = self.mass;
+
+        loop {
+            let next_fuel = calculate_fuel(mass);
+            total_fuel += next_fuel;
+            println!("Currently at mass: {:?} - next_fuel: {:?} - total_fuel: {:?}",
+                mass, next_fuel, total_fuel);
+
+            if next_fuel == 0 {
+                return total_fuel
+            } else {
+                mass = next_fuel
+            }
+        }
     }
+}
+
+fn calculate_fuel(mass: u64) -> u64 {
+    let x: f64 = mass as f64 / 3.0;
+    println!("x: {:?}", x);
+
+    let floored = x.floor() as i64;
+    println!("floored: {:?}", floored);
+    let fuel = floored - 2;
+    println!("fuel: {:?}", fuel);
+    if fuel <= 0 {
+        return 0 as u64
+    }
+    fuel as u64
 }
 
 fn read_input(file_path: &str) -> Vec<u64> {
@@ -41,16 +67,32 @@ fn part1(file_path: &str) -> u64 {
     modules.iter().map(|module| module.calculate_fuel_part1()).sum()
 }
 
+fn part2(file_path: &str) -> u64 {
+    let input_masses = read_input(file_path);
+    let modules = collect_modules(input_masses);
+
+    modules.iter().map(|module| module.calculate_fuel_part2()).sum()
+}
+
 fn main() {
     println!("Hello, world! Let's solve part 1");
     let input_file = "input.txt";
 
     println!("Part 1 answer: {}", part1(input_file));
+    println!("Part 2 answer: {}", part2(input_file));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_calculate_fuel() {
+        assert_eq!(calculate_fuel(12), 2);
+        assert_eq!(calculate_fuel(14), 2);
+        assert_eq!(calculate_fuel(1969), 654);
+        assert_eq!(calculate_fuel(100756), 33583);
+    }
 
     #[test]
     fn test_calculate_fuel_part1() {
@@ -65,7 +107,7 @@ mod tests {
         assert_eq!(Module { mass: 12 }.calculate_fuel_part2(), 2);
         assert_eq!(Module { mass: 14 }.calculate_fuel_part2(), 2);
         assert_eq!(Module { mass: 1969 }.calculate_fuel_part2(), 966);
-        // assert_eq!(Module { mass: 100756 }.calculate_fuel_part2(), 50346);
+        assert_eq!(Module { mass: 100756 }.calculate_fuel_part2(), 50346);
     }
 
     #[test]
@@ -91,5 +133,11 @@ mod tests {
     fn test_part1() {
         let input_file = "test_input.txt";
         assert_eq!(part1(input_file), 34241);
+    }
+
+    #[test]
+    fn test_part2() {
+        let input_file = "test_input.txt";
+        assert_eq!(part2(input_file), 51316);
     }
 }

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -1,7 +1,9 @@
 use std::fs;
 
 #[derive(Debug, PartialEq)]
-struct Module { mass: u64 }
+struct Module {
+    mass: u64,
+}
 
 impl Module {
     fn calculate_fuel_part1(&self) -> u64 {
@@ -15,11 +17,8 @@ impl Module {
         loop {
             let next_fuel = calculate_fuel(mass);
             total_fuel += next_fuel;
-            println!("Currently at mass: {:?} - next_fuel: {:?} - total_fuel: {:?}",
-                mass, next_fuel, total_fuel);
-
             if next_fuel == 0 {
-                return total_fuel
+                return total_fuel;
             } else {
                 mass = next_fuel
             }
@@ -29,14 +28,13 @@ impl Module {
 
 fn calculate_fuel(mass: u64) -> u64 {
     let x: f64 = mass as f64 / 3.0;
-    println!("x: {:?}", x);
 
     let floored = x.floor() as i64;
-    println!("floored: {:?}", floored);
+
+    // TODO: add a match statement here for cleaner logic? Not able to get something right now.
     let fuel = floored - 2;
-    println!("fuel: {:?}", fuel);
     if fuel <= 0 {
-        return 0 as u64
+        fuel = 0;
     }
     fuel as u64
 }
@@ -64,18 +62,23 @@ fn part1(file_path: &str) -> u64 {
     let input_masses = read_input(file_path);
     let modules = collect_modules(input_masses);
 
-    modules.iter().map(|module| module.calculate_fuel_part1()).sum()
+    modules
+        .iter()
+        .map(|module| module.calculate_fuel_part1())
+        .sum()
 }
 
 fn part2(file_path: &str) -> u64 {
     let input_masses = read_input(file_path);
     let modules = collect_modules(input_masses);
 
-    modules.iter().map(|module| module.calculate_fuel_part2()).sum()
+    modules
+        .iter()
+        .map(|module| module.calculate_fuel_part2())
+        .sum()
 }
 
 fn main() {
-    println!("Hello, world! Let's solve part 1");
     let input_file = "input.txt";
 
     println!("Part 1 answer: {}", part1(input_file));
@@ -95,11 +98,17 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_fuel_part1() {
-        assert_eq!(Module { mass: 12 }.calculate_fuel_part1(), 2);
-        assert_eq!(Module { mass: 14 }.calculate_fuel_part1(), 2);
-        assert_eq!(Module { mass: 1969 }.calculate_fuel_part1(), 654);
-        assert_eq!(Module { mass: 100756 }.calculate_fuel_part1(), 33583);
+    fn test_calculate_fuel_part1_is_same_as_calculate_fuel() {
+        let test_masses = vec![12, 14, 1969, 100756];
+        test_masses
+            .iter()
+            .map(|mass| {
+                assert_eq!(
+                    Module { mass: *mass }.calculate_fuel_part1(),
+                    calculate_fuel(*mass)
+                )
+            })
+            .collect()
     }
 
     #[test]

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -2,16 +2,16 @@ use std::fs;
 
 #[derive(Debug, PartialEq)]
 struct Module {
-    mass: u64,
+    mass: i64,
 }
 
 impl Module {
-    fn calculate_fuel_part1(&self) -> u64 {
+    fn calculate_fuel_part1(&self) -> i64 {
         calculate_fuel(self.mass)
     }
 
-    fn calculate_fuel_part2(&self) -> u64 {
-        let mut total_fuel: u64 = 0;
+    fn calculate_fuel_part2(&self) -> i64 {
+        let mut total_fuel: i64 = 0;
         let mut mass = self.mass;
 
         loop {
@@ -26,39 +26,35 @@ impl Module {
     }
 }
 
-fn calculate_fuel(mass: u64) -> u64 {
-    let x: f64 = mass as f64 / 3.0;
-
-    let floored = x.floor() as i64;
-
-    // TODO: add a match statement here for cleaner logic? Not able to get something right now.
-    let fuel = floored - 2;
+fn calculate_fuel(mass: i64) -> i64 {
+    // TODO: add a match statement or `if let` here for cleaner logic? Not able to get something right now.
+    let mut fuel = (mass / 3) - 2;
     if fuel <= 0 {
         fuel = 0;
     }
-    fuel as u64
+    fuel
 }
 
-fn read_input(file_path: &str) -> Vec<u64> {
+fn read_input(file_path: &str) -> Vec<i64> {
     let raw_contents = fs::read_to_string(file_path).expect("Unable to read file");
     let contents = raw_contents.lines();
     contents
         .map(|line| {
             line.to_string()
-                .parse::<u64>()
+                .parse::<i64>()
                 .expect("Unable to parse string to integer")
         })
         .collect()
 }
 
-fn collect_modules(input_masses: Vec<u64>) -> Vec<Module> {
+fn collect_modules(input_masses: Vec<i64>) -> Vec<Module> {
     input_masses
         .iter()
         .map(|mass| Module { mass: *mass })
         .collect()
 }
 
-fn part1(file_path: &str) -> u64 {
+fn part1(file_path: &str) -> i64 {
     let input_masses = read_input(file_path);
     let modules = collect_modules(input_masses);
 
@@ -68,7 +64,7 @@ fn part1(file_path: &str) -> u64 {
         .sum()
 }
 
-fn part2(file_path: &str) -> u64 {
+fn part2(file_path: &str) -> i64 {
     let input_masses = read_input(file_path);
     let modules = collect_modules(input_masses);
 

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -67,7 +67,10 @@ fn part1(file_path: &str) -> u64 {
 }
 
 fn main() {
-    println!("Hello, world!");
+    println!("Hello, world! Let's solve part 1");
+    let input_file = "input.txt";
+    let part1_answer = part1(input_file);
+    println!("Part 1 answer: {}", part1_answer);
 }
 
 #[cfg(test)]

--- a/rust/2019/day1/src/main.rs
+++ b/rust/2019/day1/src/main.rs
@@ -1,9 +1,7 @@
 use std::fs;
 
 #[derive(Debug, PartialEq)]
-struct Module {
-    mass: u64,
-}
+struct Module { mass: u64 }
 
 impl Module {
     fn calculate_fuel(&self) -> u64 {
@@ -12,65 +10,37 @@ impl Module {
     }
 }
 
-// fn read_input(file_path: &str) -> Vec<String> {
 fn read_input(file_path: &str) -> Vec<u64> {
-    let mut new_vec = vec![];
-    // let mut new_vec: Vec<String> = Vec::new();
-    // let contents = fs::read_to_string(file_path).expect("Unable to read file").split("\n").collect();
-
-    // TODO: figure out why try the next three lines on one results in error E0716:
-    // creates a temporary which is freed while still in use
-    // let contents: Vec<&str> = fs::read_to_string(file_path).expect("Unable to read file").split("\n").collect();
-    // println!("Got contents: {:?}", raw_contents);
-
-    // Instead have to get the raw contents and then collect them :shrug:
     let raw_contents = fs::read_to_string(file_path).expect("Unable to read file");
-    println!("Got raw_contents: {:?}", raw_contents);
-    let contents: Vec<&str> = raw_contents.split("\n").collect();
-
-    for line in contents {
-        println!("Processing line: {}", line);
-        // TODO: there must be a way to chomp final new line - just couldn't find it right away
-        if line != "" {
-            new_vec.push(
-                line.to_string()
+    let contents = raw_contents.lines();
+    contents
+        .map(|line| {
+            line.to_string()
                 .parse::<u64>()
                 .expect("Unable to parse string to integer")
-            );
-        }
-    }
-    new_vec
-}
-
-// TODO: ditch these function once all is working as desired
-fn sum_input(file_path: &str) -> u64 {
-    read_input(file_path).iter().sum()
+        })
+        .collect()
 }
 
 fn collect_modules(input_masses: Vec<u64>) -> Vec<Module> {
-    let mut modules = vec![];
-    for mass in input_masses.iter() {
-        modules.push(Module { mass: *mass })
-    }
-    modules
+    input_masses
+        .iter()
+        .map(|mass| Module { mass: *mass })
+        .collect()
 }
 
 fn part1(file_path: &str) -> u64 {
     let input_masses = read_input(file_path);
     let modules = collect_modules(input_masses);
 
-    let mut fuel_calculations = vec![];
-    for module in modules {
-        fuel_calculations.push(module.calculate_fuel());
-    }
-    fuel_calculations.iter().sum()
+    modules.iter().map(|module| module.calculate_fuel()).sum()
 }
 
 fn main() {
     println!("Hello, world! Let's solve part 1");
     let input_file = "input.txt";
-    let part1_answer = part1(input_file);
-    println!("Part 1 answer: {}", part1_answer);
+
+    println!("Part 1 answer: {}", part1(input_file));
 }
 
 #[cfg(test)]
@@ -93,23 +63,20 @@ mod tests {
     #[test]
     fn test_collect_modules() {
         let input_masses = read_input("test_input.txt");
-        assert_eq!(collect_modules(input_masses), vec![
-            Module { mass: 12 },
-            Module { mass: 14 },
-            Module { mass: 1969 },
-            Module { mass: 100756 },
-        ])
+        assert_eq!(
+            collect_modules(input_masses),
+            vec![
+                Module { mass: 12 },
+                Module { mass: 14 },
+                Module { mass: 1969 },
+                Module { mass: 100756 },
+            ]
+        )
     }
 
     #[test]
     fn test_part1() {
         let input_file = "test_input.txt";
         assert_eq!(part1(input_file), 34241);
-    }
-
-    #[test]
-    // TODO: delete this test once it is all working =)
-    fn test_sum_input() {
-        assert_eq!(sum_input("test_input.txt"), 102751)
     }
 }


### PR DESCRIPTION
# Description

Add solutions for both parts of 2019 day one in Rust. Tests are included in `src/main.rs`, which I think is the convention for unit tests.

Left one TODO for potentially adding a `match` statement, but the logic is also pretty straightforward.

Also, add a `.gitignore` for Rust