### PR TITLE
2022 Ruby day two part two - use a module for shared logic and finish these rounds

### DIFF
--- a/ruby/2022/day2/instructions.txt
+++ b/ruby/2022/day2/instructions.txt
@@ -25,3 +25,16 @@ The third round is a draw with both players choosing Scissors, giving you a scor
 In this example, if you were to follow the strategy guide, you would get a total score of 15 (8 + 1 + 6).
 
 What would your total score be if everything goes exactly according to your strategy guide?
+
+--- Part Two ---
+
+The Elf finishes helping with the tent and sneaks back over to you. "Anyway, the second column says how the round needs to end: X means you need to lose, Y means you need to end the round in a draw, and Z means you need to win. Good luck!"
+
+The total score is still calculated in the same way, but now you need to figure out what shape to choose so the round ends as indicated. The example above now goes like this:
+
+In the first round, your opponent will choose Rock (A), and you need the round to end in a draw (Y), so you also choose Rock. This gives you a score of 1 + 3 = 4.
+In the second round, your opponent will choose Paper (B), and you choose Rock so you lose (X) with a score of 1 + 0 = 1.
+In the third round, you will defeat your opponent's Scissors with Rock for a score of 1 + 6 = 7.
+Now that you're correctly decrypting the ultra top secret strategy guide, you would get a total score of 12.
+
+Following the Elf's instructions for the second column, what would your total score be if everything goes exactly according to your strategy guide?

--- a/ruby/2022/day2/lib/solver.rb
+++ b/ruby/2022/day2/lib/solver.rb
@@ -11,13 +11,15 @@ class RockPaperScissorsGame
   end
 
   def solve_part1
-    input_data.reduce(0) do |total_self_score, round|
-      total_self_score + Round.from_raw(round).self_score
-    end
+    input_data.map { |raw_round| Part1Round.from_raw(raw_round).self_score }.reduce(:+)
+  end
+
+  def solve_part2
+    input_data.map { |raw_round| Part2Round.from_raw(raw_round).self_score }.reduce(:+)
   end
 end
 
-class Round
+module Round
   SHAPE_POINTS = {
     rock: 1,
     paper: 2,
@@ -32,12 +34,19 @@ class Round
     "B" => :paper,
     "C" => :scissors,
   }
+  def self_score
+    SHAPE_POINTS.fetch(self_shape) + OUTCOME_POINTS.fetch(outcome, 0)
+  end
+end
+
+class Part1Round
+  include Round
+
   SELF_SHAPE_KEY = {
     "X" => :rock,
     "Y" => :paper,
     "Z" => :scissors,
   }
-
   attr_accessor :opponent_shape, :self_shape
 
   def initialize(opponent_shape, self_shape)
@@ -50,8 +59,8 @@ class Round
     new(OPPONENT_SHAPE_KEY[opponent_shape], SELF_SHAPE_KEY[self_shape])
   end
 
-  def self_score
-    outcome = case opponent_shape
+  def outcome
+    case opponent_shape
     when :rock
       case self_shape when :paper then :win when :rock then :draw end
     when :paper
@@ -59,7 +68,38 @@ class Round
     when :scissors
       case self_shape when :scissors then :draw when :rock then :win end
     end
-    SHAPE_POINTS.fetch(self_shape) + OUTCOME_POINTS.fetch(outcome, 0)
+  end
+end
+
+class Part2Round
+  include Round
+
+  OUTCOME_KEY = {
+    "X" => :lose,
+    "Y" => :draw,
+    "Z" => :win,
+  }
+  attr_accessor :opponent_shape, :outcome
+
+  def initialize(opponent_shape, outcome)
+    @opponent_shape = opponent_shape
+    @outcome = outcome
+  end
+
+  def self.from_raw(input_array)
+    opponent_shape, outcome = input_array
+    new(OPPONENT_SHAPE_KEY[opponent_shape], OUTCOME_KEY[outcome])
+  end
+
+  def self_shape
+    case opponent_shape
+    when :rock
+      case outcome when :lose then :scissors when :draw then :rock when :win then :paper end
+    when :paper
+      case outcome when :lose then :rock when :draw then :paper when :win then :scissors end
+    when :scissors
+      case outcome when :lose then :paper when :draw then :scissors when :win then :rock end
+    end
   end
 end
 
@@ -68,4 +108,7 @@ if $PROGRAM_NAME  == __FILE__
 
   part1 = round_info.solve_part1
   puts "Part one answer: #{part1}"
+
+  part2 = round_info.solve_part2
+  puts "Part two answer: #{part2}"
 end

--- a/ruby/2022/day2/spec/solver_spec.rb
+++ b/ruby/2022/day2/spec/solver_spec.rb
@@ -14,13 +14,19 @@ describe RockPaperScissorsGame do
   end
 
   context "#solve_part1" do
-  it "solves part one" do
-    expect(subject.solve_part1).to eq(15)
+    it "solves part one" do
+      expect(subject.solve_part1).to eq(15)
+    end
   end
+
+  context "#solve_part2" do
+    it "solves part two" do
+      expect(subject.solve_part2).to eq(12)
+    end
   end
 end
 
-describe Round do
+describe Part1Round do
   context "#from_raw" do
     let(:raw_input_array) { ["A", "Z"] }
     subject { described_class.from_raw(raw_input_array) }
@@ -30,7 +36,7 @@ describe Round do
     end
   end
 
-  context "#decide_round" do
+  context "#self_score" do
     subject { described_class.new(opponent_shape, self_shape) }
     let(:self_shape) { :placeholder }
 
@@ -105,6 +111,98 @@ describe Round do
         let(:self_shape) { :scissors }
         it "gets score for a draw" do
           expect(subject.self_score).to eq(3 + 3)
+        end
+      end
+    end
+  end
+end
+
+describe Part2Round do
+  context "#from_raw" do
+    let(:raw_input_array) { ["A", "Z"] }
+    subject { described_class.from_raw(raw_input_array) }
+
+    it "translates the raw input to a shape and an outcome" do
+      expect(subject.opponent_shape).to eq(:rock)
+      expect(subject.outcome).to eq(:win)
+    end
+  end
+
+  context "#self_score" do
+    subject { described_class.new(opponent_shape, outcome) }
+    let(:outcome) { :placeholder }
+
+    context "when the opponent plays rock" do
+      let(:opponent_shape) { :rock }
+
+      context "when desired outcome is that self should lose" do
+        let(:outcome) { :lose }
+        it "gets the score for self losing (self played scissors)" do
+          expect(subject.self_score).to eq(3 + 0)
+        end
+      end
+
+      context "when desired outcome is a draw" do
+        let(:outcome) { :draw }
+        it "gets score for a draw (self played rock)" do
+          expect(subject.self_score).to eq(1 + 3)
+        end
+      end
+
+      context "when desired outcome is a win for self" do
+        let(:outcome) { :win }
+        it "gets score for self winning (self played paper)" do
+          expect(subject.self_score).to eq(2 + 6)
+        end
+      end
+    end
+
+    context "when the opponent plays paper" do
+      let(:opponent_shape) { :paper }
+
+      context "when desired outcome is that self should lose" do
+        let(:outcome) { :lose }
+        it "gets the score for self losing (self played rock)" do
+          expect(subject.self_score).to eq(1 + 0)
+        end
+      end
+
+      context "when desired outcome is a draw" do
+        let(:outcome) { :draw }
+        it "gets score for a draw (self played paper)" do
+          expect(subject.self_score).to eq(2 + 3)
+        end
+      end
+
+      context "when desired outcome is a win for self" do
+        let(:outcome) { :win }
+        it "gets score for self winning (self played scissors" do
+          expect(subject.self_score).to eq(3 + 6)
+        end
+      end
+    end
+
+    context "when the opponent plays scissors" do
+      let(:opponent_shape) { :scissors }
+
+      context "when desired outcome is that self should lose" do
+        let(:outcome) { :lose }
+        it "gets the score for self losing (self played paper)" do
+          expect(subject.self_score).to eq(2 + 0)
+        end
+      end
+
+      context "when desired outcome is a draw" do
+        let(:outcome) { :draw }
+        it "gets score for a draw (self played scissors)" do
+          expect(subject.self_score).to eq(3 + 3)
+        end
+      end
+
+      context "when desired outcome is a win for self" do
+        let(:outcome) { :win }
+        it "gets score for self winning (self played rock)" do
+          expect(subject.self_score).to eq(1 + 6)
         end
       end
     end


### PR DESCRIPTION
## Description

Break out the shared Round logic into a module that is included in two new classes, one for each round. Define each of opponent_shape, the outcome, and the self_shape, then use a shared method to calculate the score in the same way.  Also turn the solve methods into one-liners with the totally Ruby-style `reduce(:+)`.