### PR TITLE
Add a template for solving problems in Ruby

### DIFF
--- a/ruby/start-puzzle
+++ b/ruby/start-puzzle
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# -eq 0 ]
+then
+  echo "Must specify year and day number."
+  echo "Usage: ./start-puzzle <year> <day_number>"
+  exit
+fi
+
+YEAR=$1
+DAY_NUMBER=$2
+
+# Check if year directory exists
+if [ ! -d "./${YEAR}" ]; then
+  echo "./${YEAR} does not exist. Creating it."
+  mkdir -p ./"${YEAR}"/
+fi
+
+new_directory="./${YEAR}/day${DAY_NUMBER}/"
+
+# Check if the directory already exists before writing to it, exit with info if it does
+if [ -d "${new_directory}" ]; then
+  printf "Directory %s already exists. If template still desired, delete the directory and run again:\n\n%s\n\n" \
+    "${new_directory}" "  rm -rf ${new_directory}"
+  exit 0
+else
+  cp -R template/ "${new_directory}"
+  printf "Created %s for the next puzzle\n" "${new_directory}"
+fi

--- a/ruby/template/instructions.txt
+++ b/ruby/template/instructions.txt
@@ -1,0 +1,1 @@
+Paste instructions here for later reference

--- a/ruby/template/lib/input.txt
+++ b/ruby/template/lib/input.txt
@@ -1,0 +1,1 @@
+Paste puzzle input here

--- a/ruby/template/lib/solver.rb
+++ b/ruby/template/lib/solver.rb
@@ -1,0 +1,63 @@
+class TopLevelClass
+
+  attr_accessor :input_data
+
+  def initialize(input_data)
+    @input_data = input_data
+  end
+
+  def self.from_file(filepath)
+    ###
+    # For reading each line into an array
+    # raw_content = File.foreach(filepath, chomp: true).map { |line| line.split(/ /) }
+
+    # For processing that content, for example to an integer
+    # processed_content = raw_content.map { |line| line.map(:&to_i) }
+
+    ###
+    # For reading input with line breaks that distinguish separate objects
+    # raw_content = File.read(filepath, chomp: true).split(/\n\n/)
+
+    # For processing each line within the separate objects, for example, getting the integer of each line
+    # processed_content = raw_content.map { |line| line.split(/\n/).map(&:to_i) }
+
+    # Delete this placeholder processed content before using
+    processed_content = [[4, 7], [3, 3], [2, 9]]
+
+    # Instantiate the top-level class with processed data
+    new(processed_content)
+  end
+
+  def solve_part1
+    5
+  end
+
+  def solve_part2
+    8
+  end
+end
+
+class ParticularClass
+
+  attr_accessor :input1, :input2
+
+  def initialize(input1, input2)
+    @input1 = input1
+    @input2 = input2
+  end
+
+  def self.from_raw(raw_input)
+    raw_input1, raw_input2 = raw_input
+    new(raw_input1, raw_input2)
+  end
+end
+
+if $PROGRAM_NAME  == __FILE__
+  top_level_instance = TopLevelClass.from_file("lib/input.txt")
+
+  part1 = top_level_instance.solve_part1
+  puts "Part one answer: #{part1}"
+
+  part2 = top_level_instance.solve_part2
+  puts "Part two answer: #{part2}"
+end

--- a/ruby/template/spec/solver_spec.rb
+++ b/ruby/template/spec/solver_spec.rb
@@ -1,0 +1,37 @@
+require "solver"
+
+describe TopLevelClass do
+  subject { described_class.from_file("spec/test_input.txt") }
+
+  context "#from_file" do
+    it "converts a file path to the data" do
+      expect(subject.input_data).to match_array([
+        [4, 7], [3, 3], [2, 9]
+      ])
+    end
+  end
+
+  context "#solve_part1" do
+    it "solves part one" do
+      expect(subject.solve_part1).to eq(5)
+    end
+  end
+
+  context "#solve_part2" do
+    it "solves part two" do
+      expect(subject.solve_part2).to eq(8)
+    end
+  end
+end
+
+describe ParticularClass do
+  context "#from_raw" do
+    let(:raw_input) { ["A", "Z"] }
+    subject { described_class.from_raw(raw_input) }
+
+    it "translates the raw input into separate values" do
+      expect(subject.input1).to eq("A")
+      expect(subject.input2).to eq("Z")
+    end
+  end
+end

--- a/ruby/template/spec/test_input.txt
+++ b/ruby/template/spec/test_input.txt
@@ -1,0 +1,1 @@
+Paste test input from the problem prompt here


### PR DESCRIPTION
## Describe

Add a template in the base Ruby directory with specs and input files. Define two placeholder classes: one top-level class to track progress and a lower level class that could be instantiated as part of the processing.

Specs are passing by default. The idea is that the new answer could be plugged into the specs right away with the failing "solve" method pointed out by the test failure.

~Eventually a script could be added to copy everything into the correct directory. Not sure if that's worth the time today =)~

Okay I went ahead and did it via https://github.com/coopergillan/advents-of-code/pull/37/commits/24941500ee5835f47725d311354cb480f9d2bc1d.